### PR TITLE
CI: modernize Sonar scan workflow

### DIFF
--- a/.github/workflows/sonar.yaml
+++ b/.github/workflows/sonar.yaml
@@ -16,30 +16,21 @@ jobs:
       - uses: actions/checkout@v4
         with:
           fetch-depth: 0  # Shallow clones should be disabled for a better relevancy of analysis
-      - name: Install sonar-scanner and build-wrapper
-        env:
-          SONAR_HOST_URL: ${{secrets.SONAR_HOST_URL}}
-        uses: SonarSource/sonarqube-github-c-cpp@v1
-      - name: Set up JDK 17
-        uses: actions/setup-java@v2
-        with:
-          java-version: '17'
-          distribution: 'temurin'
-      - name: Set up Node.js
-        uses: actions/setup-node@v4
-        with:
-          node-version: '18'
+      - name: Install Build Wrapper
+        uses: SonarSource/sonarqube-scan-action/install-build-wrapper@v7.0.0
       - name: Run build-wrapper
         run: |
           rm -rf build
           mkdir build
           cd build
           cmake ..
-          cmake -DCMAKE_BUILD_TYPE=Release -DCMAKE_EXPORT_COMPILE_COMMANDS=ON .
+          cmake -DCMAKE_BUILD_TYPE=Release -DCMAKE_EXPORT_COMPILE_COMMANDS=ON -DBUILD_JAVA=OFF -DBUILD_opencv_java=OFF .
           cd ..
-      - name: Run sonar-scanner
+      - name: Run SonarQube scan
+        uses: SonarSource/sonarqube-scan-action@v7.0.0
         env:
           SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}
           SONAR_HOST_URL: ${{secrets.SONAR_HOST_URL}}
-        run: |
-          sonar-scanner
+        with:
+          args: >
+            -X

--- a/sonar-project.properties
+++ b/sonar-project.properties
@@ -1,3 +1,3 @@
-sonar.projectKey=SonarSource-Demos_opencv_552f564f-bcdb-47eb-abb2-4ba7feb428ee
+sonar.projectKey=SonarSource-Demos_opencv
 sonar.cfamily.compile-commands=build/compile_commands.json
 sonar.exclusions=**/*.java


### PR DESCRIPTION
### What
- Modernize Sonar analysis workflow (move off deprecated `sonarqube-github-c-cpp` to `sonarqube-scan-action`)
- Keep build-wrapper + verbose scanner output
- Do **not** add Syft/SBOM/SCA dependency analysis
- Update `sonar.projectKey` to `SonarSource-Demos_opencv`

### Notes
- Java/Node are not explicitly installed; OpenCV Java wrappers are disabled during CMake configure.
